### PR TITLE
changed jest testEnvironment to jsdom

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -18,7 +18,7 @@
   ],
   "testMatch": ["<rootDir>/**/?(*.)spec.{js,jsx}"],
   "transformIgnorePatterns": ["node_modules/(?!@immowelt)"],
-  "testEnvironment": "node",
+  "testEnvironment": "jsdom",
   "testURL": "http://localhost",
   "transform": {
     "^.+\\.js$": "babel-jest",


### PR DESCRIPTION
BUGFIX: Because we use enzyme we need the jsdom environment for jest which allows us to use enzyme Full Rendering API.